### PR TITLE
fix: fixed null select value after delete

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,7 +19,7 @@ charset = utf-8
 # Indent style default
 indent_style = space
 # Max Line Length - a hard line wrap, should be disabled
-max_line_length = off
+# max_line_length = off
 
 [*.{py,cfg,ini}]
 # 4 space indentation

--- a/src/components/manage/Widgets/DataGridWidget.jsx
+++ b/src/components/manage/Widgets/DataGridWidget.jsx
@@ -45,7 +45,7 @@ const DataGridWidget = (props) => {
 
   const onChangeTerm = (index, field, value) => {
     let newValues = [...values];
-    newValues[index][field] = value;
+    newValues[index][field] = value || null;
 
     handleChangeConfiguration(newValues);
   };
@@ -76,32 +76,13 @@ const DataGridWidget = (props) => {
                 {schema.fieldsets.map((fieldset) => {
                   return fieldset.fields.map((field) => (
                     <Grid.Column className="field-column" key={field}>
-                      <label
-                        htmlFor={'field-' + field}
-                        className={
-                          schema.required.includes(field) ? 'required' : ''
-                        }
-                      >
+                      <label htmlFor={'field-' + field} className={schema.required.includes(field) ? 'required' : ''}>
                         {schema.properties[field].title}
                       </label>
 
-                      <Field
-                        {...schema.properties[field]}
-                        id={field}
-                        fieldSet={fieldset.title.toLowerCase()}
-                        formData={term}
-                        focus={false}
-                        value={term[field]}
-                        required={schema.required.includes(field)}
-                        onChange={(id, value) => onChangeTerm(index, id, value)}
-                        key={field}
-                        wrapped={false}
-                        placeholder={schema.properties[field].title}
-                      />
+                      <Field {...schema.properties[field]} id={field} fieldSet={fieldset.title.toLowerCase()} formData={term} focus={false} value={term[field]} required={schema.required.includes(field)} onChange={(id, value) => onChangeTerm(index, id, value)} key={field} wrapped={false} placeholder={schema.properties[field].title} />
 
-                      <p className="help">
-                        {schema.properties[field].description}
-                      </p>
+                      <p className="help">{schema.properties[field].description}</p>
                     </Grid.Column>
                   ));
                 })}

--- a/src/components/manage/Widgets/DataGridWidget.jsx
+++ b/src/components/manage/Widgets/DataGridWidget.jsx
@@ -76,13 +76,32 @@ const DataGridWidget = (props) => {
                 {schema.fieldsets.map((fieldset) => {
                   return fieldset.fields.map((field) => (
                     <Grid.Column className="field-column" key={field}>
-                      <label htmlFor={'field-' + field} className={schema.required.includes(field) ? 'required' : ''}>
+                      <label
+                        htmlFor={'field-' + field}
+                        className={
+                          schema.required.includes(field) ? 'required' : ''
+                        }
+                      >
                         {schema.properties[field].title}
                       </label>
 
-                      <Field {...schema.properties[field]} id={field} fieldSet={fieldset.title.toLowerCase()} formData={term} focus={false} value={term[field]} required={schema.required.includes(field)} onChange={(id, value) => onChangeTerm(index, id, value)} key={field} wrapped={false} placeholder={schema.properties[field].title} />
+                      <Field
+                        {...schema.properties[field]}
+                        id={field}
+                        fieldSet={fieldset.title.toLowerCase()}
+                        formData={term}
+                        focus={false}
+                        value={term[field]}
+                        required={schema.required.includes(field)}
+                        onChange={(id, value) => onChangeTerm(index, id, value)}
+                        key={field}
+                        wrapped={false}
+                        placeholder={schema.properties[field].title}
+                      />
 
-                      <p className="help">{schema.properties[field].description}</p>
+                      <p className="help">
+                        {schema.properties[field].description}
+                      </p>
                     </Grid.Column>
                   ));
                 })}


### PR DESCRIPTION
US [#44448](https://redturtle.tpondemand.com/entity/44448-datagridfield-quando-ci-sono-dei-campi) abbiamo la necessità di impostare sempre un valore `null` anche quando la select del widget viene pulita dall'icona della X, così facendo al BE viene comunque passato il parametro vuoto e non va in errore se non lo trova.